### PR TITLE
Proper arguments

### DIFF
--- a/pw.py
+++ b/pw.py
@@ -52,12 +52,7 @@ def parse_args():
 
 def main():
     args = parse_args()
-    print(args)
-if __name__ == '__main__':
-    main()
-    if len(sys.argv) == 1:
-        print(USAGE)
-    elif sys.argv[1] == '-i' or sys.argv[1] == '--init':
+    if args.init:
         master_pw = getpass.getpass("Enter a master password - DO NOT lose this or you will lose access to the passwords stored on this computer:\n")
         master_pw2 = getpass.getpass("Re-enter the master password:\n")
         if master_pw != master_pw2:
@@ -91,11 +86,11 @@ if __name__ == '__main__':
             encrypt_arr_to_file(shared_key, shared_key_file)
             print("**** Exported encrypted shared key to " + shared_key_file)
 
-    elif sys.argv[1] == '-g' or sys.argv[1] == '--generate':
+    elif args.generate:
         print ("**** GENERATING AND SAVING PASSWORD")
-        if len(sys.argv) < 3:
-            print ("**** Specify website or storage phrase to generate a password")
-            # TODO: specify options for length, etc
+        # if len(sys.argv) < 3:
+        #     print ("**** Specify website or storage phrase to generate a password")
+        #     # TODO: specify options for length, etc
 
         # TODO: allow actual character limitations
         reqUpper = True
@@ -118,7 +113,7 @@ if __name__ == '__main__':
                 break
 
         pw = "".join(str(c) for c in pw)
-        pw_filename = pw_directory + sys.argv[2]
+        pw_filename = pw_directory + args.generate
 
         master_pw = getpass.getpass("Master password: ")
         args1 = ['gpg', '-d', '--batch', '--passphrase', master_pw, shared_key_file]
@@ -130,10 +125,10 @@ if __name__ == '__main__':
         p2 = sp.Popen(args2, stdin=sp.PIPE, stdout=sp.PIPE, bufsize=1, universal_newlines=True)
         p2.stdin.write(pw)
         output = p2.communicate()[0]
-        print ("**** Saved password to {0}".format(sys.argv[2]))
+        print ("**** Saved password to {0}".format(args.generate))
 
-    elif (sys.argv[1] == "--show" or sys.argv[1] == "-s" or sys.argv[1] == "--clipboard" or sys.argv[1] == "-c") and len(sys.argv) >= 3:
-        pattern = sys.argv[2]
+    elif args.show or args.clipboard:
+        pattern = args.show or args.clipboard
         import glob
         matching_files = glob.glob(pw_directory + "*" + pattern + "*")
         if len(matching_files) == 0:
@@ -153,10 +148,10 @@ if __name__ == '__main__':
             output = p2.communicate()[0]
             output = str(output, 'UTF-8').strip()
 
-            if sys.argv[1] == "--show" or sys.argv[1] == "-s":
+            if args.show:
                 print (output)
             else:
                 print ("PRETENDING TO COPY TO CLIPBOARD")
-    else:
-        print ("****Unrecognized option")
-        print (USAGE)
+
+if __name__ == '__main__':
+    main()

--- a/pw.py
+++ b/pw.py
@@ -5,16 +5,14 @@ import getpass
 import string
 import argparse
 
-from os.path import expanduser # works on all platforms, except when Windows AD maps to network drive
+from os.path import expanduser, join # works on all platforms, except when Windows AD maps to network drive
 home_path = expanduser("~")
-pubk_directory = '{}/.pw-py/keys/'.format(home_path)
-pw_directory = '{}/.pw-py/pws/'.format(home_path)
-shared_key_file = pubk_directory + 'shared.key'
+pubk_directory = join(home_path, '.pw-py', 'keys')
+pw_directory = join(home_path, '.pw-py', 'pws')
+shared_key_file = join(pubk_directory, 'shared.key')
 
 os.makedirs(pubk_directory, exist_ok=True)
 os.makedirs(pw_directory, exist_ok=True)
-
-# USAGE = "\nNAME\n\tpw-py - password manager written in python\n\nSYNOPSIS\n\t./pw-py [OPTION] [SITENAME]\n\nDESCRIPTION\n
 
 def gen_password(length):
     import string
@@ -68,7 +66,7 @@ def main():
         print(public_key)
 
         import platform
-        pubk_filename = pubk_directory + platform.node() + ".gpg"
+        pubk_filename = join(pubk_directory, platform.node() + ".gpg")
         args = ['gpg', '--armor', '--export', 'pw-py']
         p = sp.Popen(args, stdin=sp.PIPE, stdout=sp.PIPE, bufsize=1, universal_newlines=True)
         text = p.communicate()[0]
@@ -87,9 +85,9 @@ def main():
             print("**** Exported encrypted shared key to " + shared_key_file)
 
     elif args.generate:
-        print ("**** GENERATING AND SAVING PASSWORD")
+        print("**** GENERATING AND SAVING PASSWORD")
         # if len(sys.argv) < 3:
-        #     print ("**** Specify website or storage phrase to generate a password")
+        #     print("**** Specify website or storage phrase to generate a password")
         #     # TODO: specify options for length, etc
 
         # TODO: allow actual character limitations
@@ -113,7 +111,7 @@ def main():
                 break
 
         pw = "".join(str(c) for c in pw)
-        pw_filename = pw_directory + args.generate
+        pw_filename = join(pw_directory, args.generate)
 
         master_pw = getpass.getpass("Master password: ")
         args1 = ['gpg', '-d', '--batch', '--passphrase', master_pw, shared_key_file]
@@ -125,17 +123,17 @@ def main():
         p2 = sp.Popen(args2, stdin=sp.PIPE, stdout=sp.PIPE, bufsize=1, universal_newlines=True)
         p2.stdin.write(pw)
         output = p2.communicate()[0]
-        print ("**** Saved password to {0}".format(args.generate))
+        print("**** Saved password to {0}".format(args.generate))
 
     elif args.show or args.clipboard:
         pattern = args.show or args.clipboard
         import glob
-        matching_files = glob.glob(pw_directory + "*" + pattern + "*")
+        matching_files = glob.glob(join(pw_directory, "*" + pattern + "*"))
         if len(matching_files) == 0:
-            print ("Unable to find match for: {}".format(pattern))
+            print("Unable to find match for: {}".format(pattern))
         elif len(matching_files) > 1:
-            print ("Found multiple matches, please try again specifying which one")
-            print (matching_files)
+            print("Found multiple matches, please try again specifying which one")
+            print(matching_files)
         else:
             master_pw = getpass.getpass("Master password: ")
             args1 = ['gpg', '-d', '--batch', '-q', '--passphrase', master_pw, shared_key_file]
@@ -149,9 +147,9 @@ def main():
             output = str(output, 'UTF-8').strip()
 
             if args.show:
-                print (output)
+                print(output)
             else:
-                print ("PRETENDING TO COPY TO CLIPBOARD")
+                print("PRETENDING TO COPY TO CLIPBOARD")
 
 if __name__ == '__main__':
     main()

--- a/pw.py
+++ b/pw.py
@@ -3,6 +3,7 @@ import sys, os
 import subprocess as sp
 import getpass
 import string
+import argparse
 
 from os.path import expanduser # works on all platforms, except when Windows AD maps to network drive
 home_path = expanduser("~")
@@ -13,7 +14,7 @@ shared_key_file = pubk_directory + 'shared.key'
 os.makedirs(pubk_directory, exist_ok=True)
 os.makedirs(pw_directory, exist_ok=True)
 
-USAGE = "\nNAME\n\tpw-py - password manager written in python\n\nSYNOPSIS\n\t./pw-py [OPTION] [SITENAME]\n\nDESCRIPTION\n\t-i, --initialize\n\t\tSet up local / shared key\n\t-g, --generate [SITENAME]\n\t\tgenerate password for site\n\n\t-s, --show [SITENAME]\n\t\tshow password for site\n\t-c --clipboard [SITENAME]\n\t\tcopy password for site to clipboard\n"
+# USAGE = "\nNAME\n\tpw-py - password manager written in python\n\nSYNOPSIS\n\t./pw-py [OPTION] [SITENAME]\n\nDESCRIPTION\n
 
 def gen_password(length):
     import string
@@ -38,7 +39,22 @@ def encrypt_arr_to_file(byte_arr, file_name):
     p.stdin.write("\n")
     res = p.communicate()[0]
 
+def parse_args():
+    parser = argparse.ArgumentParser(description='pw-py - password manager written in python')
+
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument('--init', '-i', action='store_true', help='Set up local / shared key')
+    action.add_argument('--generate', '-g', help='generate password for site')
+    action.add_argument('--show', '-s', help='show password for site')
+    action.add_argument('--clipboard', '-c', help='copy password for site to clipboard (implies -s)')
+
+    return parser.parse_args()
+
+def main():
+    args = parse_args()
+    print(args)
 if __name__ == '__main__':
+    main()
     if len(sys.argv) == 1:
         print(USAGE)
     elif sys.argv[1] == '-i' or sys.argv[1] == '--init':


### PR DESCRIPTION
Also normalized paths on Windows (so they are all backslashes instead of a mix).

```
$ python ./pw.py
usage: pw.py [-h]
             (--init | --generate GENERATE | --show SHOW | --clipboard CLIPBOARD)
pw.py: error: one of the arguments --init/-i --generate/-g --show/-s --clipboard/-c is required

$ python ./pw.py --help
usage: pw.py [-h]
             (--init | --generate GENERATE | --show SHOW | --clipboard CLIPBOARD)

pw-py - password manager written in python

optional arguments:
  -h, --help            show this help message and exit
  --init, -i            Set up local / shared key
  --generate GENERATE, -g GENERATE
                        generate password for site
  --show SHOW, -s SHOW  show password for site
  --clipboard CLIPBOARD, -c CLIPBOARD
                        copy password for site to clipboard (implies -s)
```